### PR TITLE
add COMMUNIBASE_API_HOST on binary request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "communibase-connector-js",
   "description": "communibase-connector-js --- a Node.js connector for the Communibase service",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "dependencies": {
     "async": "^2.1.4",
     "bluebird": "^3.4.7",

--- a/src/index.js
+++ b/src/index.js
@@ -477,6 +477,9 @@ Connector.prototype.createReadStream = function (fileId) {
 		fileStream.emit('error', new Error(http.STATUS_CODES[res.statusCode]));
 		fileStream.emit('end');
 	});
+	if (process.env.COMMUNIBASE_API_HOST) {
+		req.setHeader('Host', process.env.COMMUNIBASE_API_HOST);
+	}
 	req.end();
 	req.on('error', function (err) {
 		fileStream.emit('error', err);


### PR DESCRIPTION
when using `createReadStream` the optional `COMMUNIBASE_API_HOST` was not applied. This fixes that.